### PR TITLE
Fix window control buttons not adapting to light/dark theme

### DIFF
--- a/electron/ipc/registerHandlers.ts
+++ b/electron/ipc/registerHandlers.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
 import fs from 'fs-extra';
-import { dialog, ipcMain, shell } from 'electron';
+import { dialog, ipcMain, nativeTheme, shell } from 'electron';
 import type { OpenDialogOptions } from 'electron';
 import type { AppContext, DownloadResult, Settings } from '../types';
 import { detectSimulatorPaths } from '../services/simulatorPaths';
@@ -380,6 +380,14 @@ export function registerIpcHandlers(appContext: AppContext) {
         if (!targetWindow || targetWindow.isDestroyed()) return;
 
         targetWindow.setTitle(title);
+    });
+
+    ipcMain.handle('set-titlebar-overlay', (_event, color: string, symbolColor: string, isDark: boolean) => {
+        const targetWindow = appContext.getMainWindow();
+        if (!targetWindow || targetWindow.isDestroyed()) return;
+
+        nativeTheme.themeSource = isDark ? 'dark' : 'light';
+        targetWindow.setTitleBarOverlay({ color, symbolColor });
     });
 
     ipcMain.handle('get-disk-usage', async (): Promise<DiskUsageReport> => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -29,7 +29,8 @@ const INVOKE_CHANNELS = [
     'install-app-update',
     'get-app-version',
     'get-disk-usage',
-    'open-path'
+    'open-path',
+    'set-titlebar-overlay',
 ] as const;
 
 const ON_CHANNELS = ['download-progress', 'package-progress', 'auth-token', 'app-update-status'] as const;
@@ -137,6 +138,10 @@ const api: ElectronAPI = {
     setWindowTitle: (title) => {
         ensureInvokeChannel('set-window-title');
         return ipcRenderer.invoke('set-window-title', title);
+    },
+    setTitleBarOverlay: (color: string, symbolColor: string, isDark: boolean) => {
+        ensureInvokeChannel('set-titlebar-overlay');
+        return ipcRenderer.invoke('set-titlebar-overlay', color, symbolColor, isDark);
     },
     onDownloadProgress: (callback) => {
         ensureOnChannel('download-progress');

--- a/src/components/ThemeSync.tsx
+++ b/src/components/ThemeSync.tsx
@@ -3,6 +3,7 @@ import {useEffect} from "react";
 
 export const ThemeSync = () => {
     const theme = useThemeStore((state) => state.theme);
+    const currentTheme = useThemeStore((state) => state.currentTheme);
 
     useEffect(() => {
         console.log("ThemeSync", theme);
@@ -11,7 +12,14 @@ export const ThemeSync = () => {
             const cssVar = '--' + key.replace(/([A-Z])/g, '-$1').toLowerCase();
             root.style.setProperty(cssVar, value);
         });
-    }, [theme]);
+
+        const isDark = currentTheme === 'dark';
+        window.electronAPI?.setTitleBarOverlay(
+            isDark ? '#111111' : '#eeeeee',
+            isDark ? '#ffffff' : '#000000',
+            isDark
+        );
+    }, [theme, currentTheme]);
 
     return null;
 }

--- a/src/types/electron-api.d.ts
+++ b/src/types/electron-api.d.ts
@@ -144,6 +144,7 @@ export interface ElectronAPI {
     getInstalledLiveries: () => Promise<InstalledLiveryRecord[]>;
     setTaskbarProgress: (progress: number, mode?: 'normal' | 'indeterminate' | 'paused' | 'error' | 'none') => Promise<void>;
     setWindowTitle: (title: string) => Promise<void>;
+    setTitleBarOverlay: (color: string, symbolColor: string, isDark: boolean) => Promise<void>;
     onDownloadProgress: (callback: ((event: DownloadProgressEvent) => void) | null) => void;
     removeAllDownloadProgressListeners: () => void;
     onPackageProgress: (callback: ((event: PackageProgressEvent) => void) | null) => void;


### PR DESCRIPTION
- Added a set-titlebar-overlay IPC handler in registerHandlers.ts that calls win.setTitleBarOverlay() and sets nativeTheme.themeSource. The latter is required so Windows renders the correct hover contrast on the minimise/maximise buttons
- Wired up the channel in preload.ts and typed it in electron-api.d.ts
- Updated ThemeSync to call setTitleBarOverlay on every theme change, passing #111111/white for dark and #eeeeee/black for light (matching --panel in each theme)